### PR TITLE
Changed spell-class and changed other values to fit with the new spell-class - Forcetoss

### DIFF
--- a/spell-effects.yml
+++ b/spell-effects.yml
@@ -13,12 +13,11 @@ poison:
     targeted: true
     target-players: true
 punch:
-    spell-class: ".targeted.ForcebombSpell"
-    pushback-force: 40
-    radius: 5
+    spell-class: ".targeted.ForcetossSpell"
+    horizontal-force: 25
+    vertical-force: 10
+    range: 5
     target-players: true
-    additional-vertical-force: 20
-    max-vertical-force: 40
     effects:
         bang:
             position: target


### PR DESCRIPTION
Changed spell-class to “.targeted.ForcetossSpell”, replaced
pushback-force with horizontal-force and vertical-force. Got rid of
additional-vertical-force and max-vertical-force. Replaced radius with
range.
The values for horizontal-force and vertical-force might need a bit
of tweaking.
