### PR TITLE
Edits to blink and forage

### DIFF
--- a/spell-cantrips.yml
+++ b/spell-cantrips.yml
@@ -134,28 +134,6 @@ summon_helper:
 
 # Bonus spells
 
-blink:
-    permission-name: cantrip
-    spell-class: ".targeted.BlinkSpell"
-    always-granted: true
-    spell-icon: ender_pearl
-    description: |
-        &rBlink: Cantrip
-        &3Teleport a short distance.
-    cast-item: stick
-    cooldown: 3
-    range: 10
-    pass-through-ceiling: false
-    smoke-trail: true
-    effects:
-        - pos1 ender
-        - pos2 ender
-    cost:
-        - mana 15
-    str-cost: 15 mana
-    str-cast-self: You blink away!
-    str-cast-others: "%a blinks away!"
-    str-cant-blink: You cannot blink there.
 enderchest:
     permission-name: cantrip
     spell-class: ".instant.EnderchestSpell"
@@ -170,11 +148,6 @@ enderchest:
         - mana 50
         - 368 1
     str-cost: 50 mana and an enderpearl.
-
-
-
-
-
 
 
 

--- a/spells-school-forest.yml
+++ b/spells-school-forest.yml
@@ -175,25 +175,39 @@ woodland_concoction:
 
 forage:
     permission-name: forest
-    spell-class: ".instant.FoodSpell"
+    spell-class: ".instant.ConjureSpell"
     cast-item: stick,forest_sickle
     spell-icon: apple
-    memory: 1
+    memory: 4
+    prerequisites:
+        - woodland_concoction
     cost:
-        - mana 5
+        - mana 10
+        - seeds 6
     cooldown: 0.5
-    food: 1
-    saturation: 2
+    calculate-drops-individually: false
+    power-affects-quantity: true
+    items:
+        - wheat 1-6 20%
+        - apple 2-6 15%
+        - carrot 3-9 18%
+        - potato 4-8 17%
+        - brown_mushroom 1-4 14%
+        - red_mushroom 1-2 6%
+        - pumpkin 1 5%
+        - melon_block 1 3%
+        - egg 1 2%
     modifiers:
-        - holding "359|&2Magic Sickle" power 2
-        - storm denied
+        - holding "359|&2Magic Sickle" power 2.5
+        - biome FOREST,PLAINS,FOREST_HILLS,BIRCH_FOREST,BIRCH_FOREST_HILLS,ROOFED_FOREST,SUNFLOWER_PLAINS,FLOWER_FOREST,JUNGLE,JUNGLE_HILLS,JUNGLE_EDGE required
+        - elevationabove 62 required
     description: |
-            &2Forage: 1 Memory Forest Spell
+            &2Forage: 4 Memory Forest Spell
             You discover sources of food in the wilderness.
-    str-cost: 5 mana.  Uses 1 memory slot.
-    str-cast-self: You feel less hungry.
-    str-modifier-failed: It's dangerous to forage in a storm! Wait for the weather to clear.
-    str-on-cooldown: ""
+            This will only work in certain biomes, and not underground.
+    str-cost: 10 mana and 6 seeds.
+    str-modifier-failed: This is not good foraging terrain.
+    str-on-cooldown: "Rummage..."
     effects:
         munch:
             position: caster

--- a/spells-school-shadow.yml
+++ b/spells-school-shadow.yml
@@ -25,6 +25,31 @@ blind:
       victim:
         position: target
         effect: smoke
+blink:
+    permission-name: cantrip
+    spell-class: ".targeted.BlinkSpell"
+    memory: 3
+    spell-icon: ender_pearl
+    description: |
+        &rBlink   3 Memory   Shadow School
+        &3Teleport a short distance.
+    cast-item: stick
+    cooldown: 3
+    range: 6
+    spell-power-affects-range: true
+    pass-through-ceiling: false
+    smoke-trail: true
+    effects:
+        - pos1 ender
+        - pos2 ender
+    cost:
+        - mana 15
+    str-cost: 15 mana
+    str-cast-self: You blink away!
+    str-cast-others: "%a blinks away!"
+    str-cant-blink: You cannot blink there.
+    modifiers:
+      - lightlevelbelow 8 power 2
 invisibility:
     permission-name: shadow
     spell-class: ".buff.InvisibilitySpell"


### PR DESCRIPTION
Two changes in this request.  Blink has been moved from cantrip to shadow magic, and given a light-based (er, shadow-based) modifier and a memory cost.

Forage now produces food items rather than hunger.  I assume the anti-storm thing was an anti-vampire thing, so I changed it on a whim.
